### PR TITLE
updated regex for new schemaorg standard

### DIFF
--- a/biothings_schema/dataload.py
+++ b/biothings_schema/dataload.py
@@ -56,8 +56,8 @@ def load_json_or_yaml(file_path):
 @timed_lru_cache(seconds=3600, maxsize=10)  # caching for 1hr
 def get_latest_schemaorg_version():
     """Get the latest version of schemaorg from its github"""
-    tag_name = requests.get(SCHEMAORG_VERSION_URL).json()["tag_name"]  # "v13.0-release"
-    mat = re.match(r"v([\d.]+)-release", tag_name)
+    tag_name = requests.get(SCHEMAORG_VERSION_URL).json()["tag_name"]  # "v13.0-release" or "v30.0"
+    mat = re.match(r"v([\d.]+)(?:-release)?", tag_name)
     if not mat:
         raise ValueError(f"Unrecognized release tag name {tag_name}")
     latest = mat.group(1)

--- a/biothings_schema/dataload.py
+++ b/biothings_schema/dataload.py
@@ -27,7 +27,7 @@ def load_json_or_yaml(file_path):
         return file_path
     # handle url
     elif file_path.startswith("http"):
-        with requests.get(file_path) as url:
+        with requests.get(file_path, timeout=10) as url:
             # check if http requests returns a success status code
             if url.status_code != 200:
                 raise ValueError(f"Invalid URL [{url.status_code}]: {file_path} !")
@@ -55,9 +55,18 @@ def load_json_or_yaml(file_path):
 
 @timed_lru_cache(seconds=3600, maxsize=10)  # caching for 1hr
 def get_latest_schemaorg_version():
-    """Get the latest version of schemaorg from its github"""
-    tag_name = requests.get(SCHEMAORG_VERSION_URL).json()["tag_name"]  # "v13.0-release" or "v30.0"
+    # This code fetches the schemaorg version from the Github API
+    # - It handles network calls gracefully, with a timeout and exception handling
+    # - It parses the tag name using a regex to extract the version number,
+    # with a regex that can handle both old and new tag formats (e.g. "v13.0-release" and "v30.0")
+    try:
+        tag_name = requests.get(SCHEMAORG_VERSION_URL, timeout=10).json()["tag_name"]
+        # "v13.0-release" or "v30.0"
+    except requests.RequestException as e:
+        raise ValueError(f"Failed to fetch schema.org version: {e}") from e
     mat = re.match(r"v([\d.]+)(?:-release)?", tag_name)
+
+    # If the tag name doesn't match the expected format, raise a ValueError with a clear message
     if not mat:
         raise ValueError(f"Unrecognized release tag name {tag_name}")
     latest = mat.group(1)

--- a/tests/test_schema_org.py
+++ b/tests/test_schema_org.py
@@ -58,7 +58,6 @@ class TestSchemaOrg(unittest.TestCase):
 
 
 class TestGetSchemaorgVersion(unittest.TestCase):
-
     """Test schema.org release tag parsing and fallback behavior."""
 
     def setUp(self):

--- a/tests/test_schema_org.py
+++ b/tests/test_schema_org.py
@@ -79,27 +79,27 @@ class TestGetSchemaorgVersion(unittest.TestCase):
     # The following tests require mocking since we need to simulate
     # edge cases that cannot be reproduced with a live API call.
 
-    @unittest.mock.patch("biothings_schema.dataload.requests.get")
+    @patch("biothings_schema.dataload.requests.get")
     def test_tag_with_release_suffix(self, mock_get):
         """Old tag format v13.0-release is still parsed correctly"""
-        mock_get.return_value = unittest.mock.MagicMock()
+        mock_get.return_value = MagicMock()
         mock_get.return_value.json.return_value = {"tag_name": "v13.0-release"}
         self.assertEqual(get_latest_schemaorg_version(), "13.0")
 
-    @unittest.mock.patch("biothings_schema.dataload.requests.get")
+    @patch("biothings_schema.dataload.requests.get")
     def test_unrecognized_tag_raises_value_error(self, mock_get):
         """Unrecognized tag format raises ValueError"""
-        mock_get.return_value = unittest.mock.MagicMock()
+        mock_get.return_value = MagicMock()
         mock_get.return_value.json.return_value = {"tag_name": "something-weird"}
         with self.assertRaises(ValueError):
             get_latest_schemaorg_version()
 
-    @unittest.mock.patch("biothings_schema.dataload.requests.get", side_effect=requests.exceptions.Timeout)
+    @patch("biothings_schema.dataload.requests.get", side_effect=requests.exceptions.Timeout)
     def test_timeout_falls_back_to_default(self, _):
         """Network timeout falls back to default version"""
         self.assertEqual(get_schemaorg_version(), SCHEMAORG_DEFAULT_VERSION)
 
-    @unittest.mock.patch("biothings_schema.dataload.requests.get", side_effect=requests.exceptions.ConnectionError)
+    @patch("biothings_schema.dataload.requests.get", side_effect=requests.exceptions.ConnectionError)
     def test_connection_error_falls_back_to_default(self, _):
         """Connection error falls back to default version"""
         self.assertEqual(get_schemaorg_version(), SCHEMAORG_DEFAULT_VERSION)

--- a/tests/test_schema_org.py
+++ b/tests/test_schema_org.py
@@ -1,6 +1,11 @@
 import unittest
+from unittest.mock import MagicMock, patch
+
+import requests
 
 from biothings_schema import Schema
+from biothings_schema.dataload import get_latest_schemaorg_version, get_schemaorg_version
+from biothings_schema.settings import SCHEMAORG_DEFAULT_VERSION
 
 
 class TestSchemaOrg(unittest.TestCase):
@@ -50,6 +55,54 @@ class TestSchemaOrg(unittest.TestCase):
             # test describe function
             describe = sp.describe()
             del describe
+
+
+class TestGetSchemaorgVersion(unittest.TestCase):
+    """Test schema.org release tag parsing and fallback behavior"""
+
+    def setUp(self):
+        get_latest_schemaorg_version.cache_clear()
+
+    def tearDown(self):
+        get_latest_schemaorg_version.cache_clear()
+
+    def test_get_latest_schemaorg_version(self):
+        """Live call: get_latest_schemaorg_version() returns a valid version string"""
+        version = get_latest_schemaorg_version()
+        self.assertRegex(version, r"^\d+\.\d+$")
+
+    def test_get_schemaorg_version(self):
+        """Live call: get_schemaorg_version() returns a valid version string"""
+        version = get_schemaorg_version()
+        self.assertRegex(version, r"^\d+\.\d+$")
+
+    # The following tests require mocking since we need to simulate
+    # edge cases that cannot be reproduced with a live API call.
+
+    @unittest.mock.patch("biothings_schema.dataload.requests.get")
+    def test_tag_with_release_suffix(self, mock_get):
+        """Old tag format v13.0-release is still parsed correctly"""
+        mock_get.return_value = unittest.mock.MagicMock()
+        mock_get.return_value.json.return_value = {"tag_name": "v13.0-release"}
+        self.assertEqual(get_latest_schemaorg_version(), "13.0")
+
+    @unittest.mock.patch("biothings_schema.dataload.requests.get")
+    def test_unrecognized_tag_raises_value_error(self, mock_get):
+        """Unrecognized tag format raises ValueError"""
+        mock_get.return_value = unittest.mock.MagicMock()
+        mock_get.return_value.json.return_value = {"tag_name": "something-weird"}
+        with self.assertRaises(ValueError):
+            get_latest_schemaorg_version()
+
+    @unittest.mock.patch("biothings_schema.dataload.requests.get", side_effect=requests.exceptions.Timeout)
+    def test_timeout_falls_back_to_default(self, _):
+        """Network timeout falls back to default version"""
+        self.assertEqual(get_schemaorg_version(), SCHEMAORG_DEFAULT_VERSION)
+
+    @unittest.mock.patch("biothings_schema.dataload.requests.get", side_effect=requests.exceptions.ConnectionError)
+    def test_connection_error_falls_back_to_default(self, _):
+        """Connection error falls back to default version"""
+        self.assertEqual(get_schemaorg_version(), SCHEMAORG_DEFAULT_VERSION)
 
 
 if __name__ == "__main__":

--- a/tests/test_schema_org.py
+++ b/tests/test_schema_org.py
@@ -58,7 +58,7 @@ class TestSchemaOrg(unittest.TestCase):
 
 
 class TestGetSchemaorgVersion(unittest.TestCase):
-    """Test schema.org release tag parsing and fallback behavior."""
+    # Test schema.org release tag parsing and fallback behavior.
 
     def setUp(self):
         get_latest_schemaorg_version.cache_clear()

--- a/tests/test_schema_org.py
+++ b/tests/test_schema_org.py
@@ -58,7 +58,8 @@ class TestSchemaOrg(unittest.TestCase):
 
 
 class TestGetSchemaorgVersion(unittest.TestCase):
-    """Test schema.org release tag parsing and fallback behavior"""
+
+    """Test schema.org release tag parsing and fallback behavior."""
 
     def setUp(self):
         get_latest_schemaorg_version.cache_clear()
@@ -67,12 +68,12 @@ class TestGetSchemaorgVersion(unittest.TestCase):
         get_latest_schemaorg_version.cache_clear()
 
     def test_get_latest_schemaorg_version(self):
-        """Live call: get_latest_schemaorg_version() returns a valid version string"""
+        """Live call: get_latest_schemaorg_version() returns a valid version string."""
         version = get_latest_schemaorg_version()
         self.assertRegex(version, r"^\d+\.\d+$")
 
     def test_get_schemaorg_version(self):
-        """Live call: get_schemaorg_version() returns a valid version string"""
+        """Live call: get_schemaorg_version() returns a valid version string."""
         version = get_schemaorg_version()
         self.assertRegex(version, r"^\d+\.\d+$")
 
@@ -81,14 +82,14 @@ class TestGetSchemaorgVersion(unittest.TestCase):
 
     @patch("biothings_schema.dataload.requests.get")
     def test_tag_with_release_suffix(self, mock_get):
-        """Old tag format v13.0-release is still parsed correctly"""
+        """Old tag format v13.0-release is still parsed correctly."""
         mock_get.return_value = MagicMock()
         mock_get.return_value.json.return_value = {"tag_name": "v13.0-release"}
         self.assertEqual(get_latest_schemaorg_version(), "13.0")
 
     @patch("biothings_schema.dataload.requests.get")
     def test_unrecognized_tag_raises_value_error(self, mock_get):
-        """Unrecognized tag format raises ValueError"""
+        """Unrecognized tag format raises ValueError."""
         mock_get.return_value = MagicMock()
         mock_get.return_value.json.return_value = {"tag_name": "something-weird"}
         with self.assertRaises(ValueError):
@@ -96,12 +97,12 @@ class TestGetSchemaorgVersion(unittest.TestCase):
 
     @patch("biothings_schema.dataload.requests.get", side_effect=requests.exceptions.Timeout)
     def test_timeout_falls_back_to_default(self, _):
-        """Network timeout falls back to default version"""
+        """Network timeout falls back to default version."""
         self.assertEqual(get_schemaorg_version(), SCHEMAORG_DEFAULT_VERSION)
 
     @patch("biothings_schema.dataload.requests.get", side_effect=requests.exceptions.ConnectionError)
     def test_connection_error_falls_back_to_default(self, _):
-        """Connection error falls back to default version"""
+        """Connection error falls back to default version."""
         self.assertEqual(get_schemaorg_version(), SCHEMAORG_DEFAULT_VERSION)
 
 


### PR DESCRIPTION
Fix schema.org version tag regex and improve error handling. 
  
**Problem**:
Schema.org changed their GitHub release tag format from `v29.0-release` to `v30.0` (dropping the `-release` suffix). The existing regex `v([\d.]+)-release` fails to parse the new format, causing a `ValueError` and breaking schema loading.  
  
**Changes**: 
  
`biothings_schema/dataload.py`:    
•  Updated the version tag regex from `v([\d.]+)-release to v([\d.]+)(?:-release)?`, supporting both old and new tag formats.  
•  Added `timeout=10` to `requests.get()` calls in `load_json_or_yaml` and `get_latest_schemaorg_version` to prevent indefinite hangs.  
•  Wrapped the GitHub API call in `get_latest_schemaorg_version` with try/except requests.RequestException so network failures are converted to `ValueError` and handled gracefully by the existing fallback in `get_schemaorg_version`.  
  
`tests/test_schema_org.py`    
•  Added `TestGetSchemaorgVersion` test class with:  
◦  Live tests verifying `get_latest_schemaorg_version()` and `get_schemaorg_version()` return valid version strings.
◦  Mocked tests for the old tag format (`v13.0-release`), unrecognized tags, and network errors (Timeout, ConnectionError) to verify fallback to `SCHEMAORG_DEFAULT_VERSION`.  